### PR TITLE
Fix rust examples

### DIFF
--- a/changelog/v0.0.12/rust-examples.yaml
+++ b/changelog/v0.0.12/rust-examples.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Improve rust example documentation and fix envoy-proxy function signatures

--- a/example/rust/README.md
+++ b/example/rust/README.md
@@ -4,5 +4,25 @@ The rust SDK is a WIP.
 
 ## rust if you want to use it or rebuild the rust WebAssembly tests
 
-curl https://sh.rustup.rs -sSf | sh
+`curl https://sh.rustup.rs -sSf | sh`
+
+## Add the WASM target
+Need to add the wasm target before we can compile rust for it:
+
+`rustup target add wasm32-unknown-unknown`
+
+## Building WASM
+The example projects use cargo, so there are two ways to build the project:
+
+1. Will build a development copy:
+    `cargo build --target wasm32-unknown-unknown`
+2. Build for release:
+    `cargo build --target wasm32-unknown-unknown --release`
+
+## Deploy using wasme
+Once you build the .wasm file you can publish it to the Hub using wasme. Navigate to the `rust/target/wasm32-unknown-unknown/release` directory and run:
+`wasme push webassemblyhub.io/<github username>/<filter-name>:v0.1 ./wasm_filter_bindings.wasm`
+
+## More about wasme
+For more information about using wasme and the WebAssemblyHub [check here](https://docs.solo.io/web-assembly-hub/latest/tutorial_code/getting_started_1/).
 

--- a/example/rust/src/host.rs
+++ b/example/rust/src/host.rs
@@ -11,15 +11,15 @@ extern "C" {
     // header values
     pub fn proxy_add_header_map_value(
         hm_type: HeaderMapType,
-        key_ptr: c_char,
+        key_ptr: *const c_char,
         key_size: usize,
-        value_ptr: c_char,
-        value_size: *mut usize,
+        value_ptr: *const c_char,
+        value_size: usize,
     ) -> WasmResult;
 
     pub fn proxy_get_header_map_value(
         hm_type: HeaderMapType,
-        key_ptr: c_char,
+        key_ptr: *const c_char,
         key_size: usize,
         value_ptr: *const c_char,
         value_size: *mut usize,
@@ -33,13 +33,13 @@ extern "C" {
 
     pub fn proxy_get_header_map_pairs(
         hm_type: HeaderMapType,
-        ptr: c_char,
+        ptr: *const c_char,
         size: usize,
     ) -> WasmResult;
 
     pub fn proxy_replace_header_map_value(
         hm_type: HeaderMapType,
-        key_ptr: c_char,
+        key_ptr: *const c_char,
         size: usize,
         value_ptr: *const c_char,
         value_size: usize,
@@ -47,7 +47,7 @@ extern "C" {
 
     pub fn proxy_remove_header_map_value(
         hm_type: HeaderMapType,
-        key_ptr: c_char,
+        key_ptr: *const c_char,
         key_size: usize,
     ) -> WasmResult;
 


### PR DESCRIPTION
Add some more details to how to build wasm plugins via rust and cargo. Fixes some of the proxy function signatures to reflect what envoy expects. I used [this list](https://github.com/envoyproxy/envoy-wasm/blob/master/api/wasm/cpp/proxy_wasm_externs.h) to compare the signatures.