### PR TITLE
Let wasme cache use OCI registry credentials

### DIFF
--- a/changelog/v0.0.20/command-line-credentials.yaml
+++ b/changelog/v0.0.20/command-line-credentials.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Allow wasme cache to use credentials given to its command line.
+    issueLink: https://github.com/solo-io/wasme/pull/102

--- a/pkg/cmd/cache/cache.go
+++ b/pkg/cmd/cache/cache.go
@@ -70,7 +70,7 @@ func CacheCmd(ctx *context.Context, loginOptions *opts.AuthOptions) *cobra.Comma
 
 func runCache(ctx context.Context, opts cacheOptions) error {
 
-	imageCache := defaults.NewDefaultCache()
+	imageCache := defaults.NewDefaultCache(opts.AuthOptions)
 	for _, image := range opts.targetRefs {
 		digest, err := imageCache.Add(context.TODO(), image)
 		if err != nil {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -5,13 +5,14 @@ import (
 	"path/filepath"
 
 	"github.com/solo-io/wasme/pkg/cache"
+	"github.com/solo-io/wasme/pkg/cmd/opts"
 	"github.com/solo-io/wasme/pkg/pull"
 	"github.com/solo-io/wasme/pkg/resolver"
 )
 
-func NewDefaultCache() cache.Cache {
-	// cache doesn't need authorizer as it doesn't push
-	resolver, _ := resolver.NewResolver("", "", true, false)
+func NewDefaultCache(opts *opts.AuthOptions) cache.Cache {
+	// Pull command from a private registry still needs authorizer
+	resolver, _ := resolver.NewResolver(opts.Username, opts.Password, opts.Insecure, opts.PlainHTTP, opts.CredentialsFiles...)
 	puller := pull.NewPuller(resolver)
 
 	return cache.NewCache(puller)


### PR DESCRIPTION
This is the first step to resolve #101

The wasme cache will now use credentials given to its command line.

Separately, we will have to look at a way to pick the [FilterDeployment pullSecret](https://github.com/solo-io/wasme/blob/master/operator/api/wasme/v1/filter_deployment.proto#L58) dynamically.

For the time being, people who want to try this with the operator need a few extra steps.

### Create a secret with the appropriate username and password

```bash
kubectl create secret generic image-registry --dry-run --output=yaml \
  --from-literal=username=$GCR_USER \
  --from-literal=password="$GCR_PASSWORD" -n wasme | kubectl apply -f -
```

### Change the wasme-cache daemon set

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    app: wasme-cache
  name: wasme-cache
  namespace: wasme
spec:
  selector:
    matchLabels:
      app: wasme-cache
  template:
    metadata:
      labels:
        app: wasme-cache
      annotations:
        prometheus.io/path: /metrics
        prometheus.io/port: '9091'
        prometheus.io/scrape: 'true'
    spec:
      serviceAccountName: wasme-cache
      volumes:
        - hostPath:
            path: /var/local/lib/wasme-cache
            type: DirectoryOrCreate
          name: cache-dir
        - configMap:
            items:
              - key: images
                path: images.txt
            name: wasme-cache
          name: config
      containers:
        - image: quay.io/solo-io/wasme:dev
          command:
            - /bin/sh
          args:
            - -c
            - 'wasme cache --ref-file /etc/wasme-cache/images.txt --directory /var/local/lib/wasme-cache --cache-ns wasme -u "$REGISTRY_USERNAME" -p "$REGISTRY_PASSWORD" -v'
          env:
            - name: REGISTRY_USERNAME
              valueFrom:
                secretKeyRef:
                  name: image-registry
                  key: username
            - name: REGISTRY_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: image-registry
                  key: password
          volumeMounts:
            - mountPath: /var/local/lib/wasme-cache
              name: cache-dir
            - mountPath: /etc/wasme-cache
              name: config
          imagePullPolicy: IfNotPresent
          name: wasme-cache
          resources:
            limits:
              cpu: 500m
              memory: 256Mi
            requests:
              cpu: 50m
              memory: 128Mi
          securityContext:
            readOnlyRootFilesystem: true
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
```

BOT NOTES: 
resolves https://github.com/solo-io/wasme/pull/102