### PR TITLE
Fix Bookinfo URL

### DIFF
--- a/changelog/v0.0.21/fix-bookinfo-url
+++ b/changelog/v0.0.21/fix-bookinfo-url
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix Bookinfo URL.
+    issueLink: https://github.com/solo-io/wasme/issues/122

--- a/docs/content/tutorial_code/wasme_operator.md
+++ b/docs/content/tutorial_code/wasme_operator.md
@@ -112,7 +112,7 @@ kubectl create ns bookinfo
 kubectl label namespace bookinfo istio-injection=enabled --overwrite
 
 # install the bookinfo application
-kubectl apply -n bookinfo -f https://github.com/solo-io/wasme/blob/master/test/e2e/operator/bookinfo.yaml
+kubectl apply -n bookinfo -f https://raw.githubusercontent.com/solo-io/wasme/master/test/e2e/operator/bookinfo.yaml
 ```
 
 {{% notice note %}}


### PR DESCRIPTION
Previously, the kubectl apply pointed at GitHub's html page rather than at the raw file. This gave:

```
error: error parsing https://github.com/solo-io/wasme/blob/master/test/e2e/operator/bookinfo.yaml: error converting YAML to JSON: yaml: line 116: mapping values are not allowed in this context

```
BOT NOTES: 
resolves https://github.com/solo-io/wasme/issues/122