### PR TITLE
Added noop cloud build file to pass CI

### DIFF
--- a/changelog/v0.0.21/add-noop-cloudbuild.yaml
+++ b/changelog/v0.0.21/add-noop-cloudbuild.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add a noop step to cloudbuild so that builds pass CI

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['version']
+  id: 'empty noop to pass CI & make the bots happy'


### PR DESCRIPTION
When this file was removed, bulldozer bot broke. We should
remove the cloudbuild dependency from bulldozer bot as a long
term solution, but to restore functionality this file serves as
a workaround.