### PR TITLE
Fix bulldozer

### DIFF
--- a/changelog/v0.0.21/fix-bulldozer-bot.yaml
+++ b/changelog/v0.0.21/fix-bulldozer-bot.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Removed cloudbuild files as bulldozer bot is now working as expected.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,0 @@
-steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['version']
-  id: 'empty noop to pass CI & make the bots happy'


### PR DESCRIPTION
Permissions issue was fixed, bulldozer does not need a valid cloudbuild config to run. 