### PR TITLE
Support Istio 1.6

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -73,3 +73,56 @@ jobs:
         # see what's in the cluster if we failed
         kubectl get all -A
         kubectl get configmaps -A
+  e2e-istio-1_6:
+    name: e2e-test-istio 1.6
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14
+    - uses: engineerd/setup-kind@v0.3.0
+      with:
+        skipClusterCreation: "true"
+    - name: Install Protoc
+      uses: solo-io/setup-protoc@master
+      with:
+        version: '3.6.1'
+    - uses: azure/setup-kubectl@v1
+      id: kubectl
+      with:
+        version: 'v1.18.0'
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Setup env
+      env:
+        KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
+      run: |
+        curl -sSL https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz | tar -xzf - linux-amd64/helm
+        curl -sSL https://github.com/istio/istio/releases/download/1.6.6/istio-1.6.6-linux.tar.gz | tar -xzf - istio-1.6.6/bin/istioctl
+        export PATH=$PWD/istio-1.6.6/bin:$PWD/linux-amd64:$(dirname $KUBECTL):$PATH
+        go get -u github.com/onsi/ginkgo/ginkgo
+        make install-deps
+        ./ci/setup-kind.sh
+    - name: Testing
+      env:
+        KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
+        TEST_PKG: test/e2e/operator
+      run: |
+        export PATH=$(dirname $KUBECTL):$PATH
+        export FILTER_IMAGE_ISTIO_TAG=webassemblyhub.io/ilackarms/assemblyscript-test:istio-1.5
+        export FILTER_BUILD_IMAGE_TAG=localhost:5000/test:v1
+        make run-tests
+    - name: Debug Info
+      if: failure()
+      env:
+        KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
+      run: |
+        # see what's in the cluster if we failed
+        kubectl get all -A
+        kubectl get configmaps -A

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -104,7 +104,7 @@ jobs:
         KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
       run: |
         curl -sSL https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz | tar -xzf - linux-amd64/helm
-        curl -sSL https://github.com/istio/istio/releases/download/1.6.6/istio-1.6.6-linux.tar.gz | tar -xzf - istio-1.6.6/bin/istioctl
+        curl -sSL https://github.com/istio/istio/releases/download/1.6.6/istio-1.6.6-linux-amd64.tar.gz | tar -xzf - istio-1.6.6/bin/istioctl
         export PATH=$PWD/istio-1.6.6/bin:$PWD/linux-amd64:$(dirname $KUBECTL):$PATH
         go get -u github.com/onsi/ginkgo/ginkgo
         make install-deps

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -112,10 +112,10 @@ jobs:
     - name: Testing
       env:
         KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
-        TEST_PKG: test/e2e/operator
       run: |
         export PATH=$(dirname $KUBECTL):$PATH
         export FILTER_IMAGE_ISTIO_TAG=webassemblyhub.io/ilackarms/assemblyscript-test:istio-1.5
+        export FILTER_IMAGE_GLOO_TAG=webassemblyhub.io/sodman/example-filter:v0.3
         export FILTER_BUILD_IMAGE_TAG=localhost:5000/test:v1
         make run-tests
     - name: Debug Info

--- a/changelog/v0.0.21/add-istio-1.6-support.yaml
+++ b/changelog/v0.0.21/add-istio-1.6-support.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: 'Add support for Istio v1.6.x'
+    issueLink: https://github.com/solo-io/wasme/issues/126

--- a/docs/content/reference/cli/wasme_deploy_istio.md
+++ b/docs/content/reference/cli/wasme_deploy_istio.md
@@ -15,7 +15,7 @@ wasme deploys a server-side cache component which runs in cluster and pulls filt
 
 If --name is not provided, all deployments in the targeted namespace will attach the filter.
 
-Note: currently only Istio 1.5.x is supported.
+Note: currently only Istio 1.5.x and 1.6.x are supported.
 
 
 ```

--- a/docs/content/reference/cli/wasme_init.md
+++ b/docs/content/reference/cli/wasme_init.md
@@ -30,7 +30,7 @@ wasme init DEST_DIRECTORY [--language=FILTER_LANGUAGE] [--platform=TARGET_PLATFO
   -h, --help                      help for init
       --language string           The programming language with which to create the filter. Supported languages are: [cpp assemblyscript]
       --platform string           The name of the target platform against which to build. Supported platforms are: [gloo istio]
-      --platform-version string   The version of the target platform against which to build. Supported Istio versions are: [1.5.x]. Supported Gloo versions are: [1.3.x 1.5.x]
+      --platform-version string   The version of the target platform against which to build. Supported Istio versions are: [1.5.x 1.6.x]. Supported Gloo versions are: [1.3.x 1.5.x]
 ```
 
 ### Options inherited from parent commands

--- a/pkg/abi/version.go
+++ b/pkg/abi/version.go
@@ -13,6 +13,7 @@ const (
 
 	Version13x = "1.3.x"
 	Version15x = "1.5.x"
+	Version16x = "1.6.x"
 )
 
 // an abi provider
@@ -93,6 +94,10 @@ var (
 		Name:    PlatformNameIstio,
 		Version: Version15x,
 	}
+	Istio16 = Platform{
+		Name:    PlatformNameIstio,
+		Version: Version16x,
+	}
 	Gloo13 = Platform{
 		Name:    PlatformNameGloo,
 		Version: Version13x,
@@ -103,11 +108,13 @@ var (
 	}
 
 	Version_097b7f2e4cc1fb490cc1943d0d633655ac3c522f = Version{
+		// December 12 2019
 		Name:       "v0-097b7f2e4cc1fb490cc1943d0d633655ac3c522f",
 		Repository: "https://github.com/envoyproxy/envoy-wasm",
 		Commit:     "097b7f2e4cc1fb490cc1943d0d633655ac3c522f",
 	}
 	Version_edc016b1fa5adca3ebd3d7020eaed0ad7b8814ca = Version{
+		// July 7th 2020
 		Name:       "v0-edc016b1fa5adca3ebd3d7020eaed0ad7b8814ca",
 		Repository: "https://github.com/envoyproxy/envoy-wasm",
 		Commit:     "edc016b1fa5adca3ebd3d7020eaed0ad7b8814ca",
@@ -119,6 +126,7 @@ var (
 		},
 		Version_097b7f2e4cc1fb490cc1943d0d633655ac3c522f: {
 			Istio15,
+			Istio16,
 		},
 	}
 )

--- a/pkg/abi/version_test.go
+++ b/pkg/abi/version_test.go
@@ -19,5 +19,7 @@ var _ = Describe("ABI Version Registry", func() {
 		err = DefaultRegistry.ValidateIstioVersion([]string{Version_edc016b1fa5adca3ebd3d7020eaed0ad7b8814ca.Name}, "1.5.32")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("no versions of istio found which support abi versions"))
+		err = DefaultRegistry.ValidateIstioVersion([]string{Version_097b7f2e4cc1fb490cc1943d0d633655ac3c522f.Name}, "1.6.0")
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/cmd/deploy/deploy.go
+++ b/pkg/cmd/deploy/deploy.go
@@ -128,7 +128,7 @@ wasme deploys a server-side cache component which runs in cluster and pulls filt
 
 If --name is not provided, all deployments in the targeted namespace will attach the filter.
 
-Note: currently only Istio 1.5.x is supported.
+Note: currently only Istio 1.5.x and 1.6.x are supported.
 `
 	cmd := makeDeployCommand(ctx, opts,
 		Provider_Istio,

--- a/pkg/cmd/initialize/initialize.go
+++ b/pkg/cmd/initialize/initialize.go
@@ -75,6 +75,7 @@ var availableBases = map[string][]filterBase{
 			// cpp for istio 1.5
 			compatiblePlatforms: compatiblePlatforms{
 				abi.Istio15,
+				abi.Istio16,
 			},
 			archiveBytes: cppIstio1_5TarBytes,
 		},
@@ -90,6 +91,7 @@ var availableBases = map[string][]filterBase{
 			compatiblePlatforms: compatiblePlatforms{
 				abi.Gloo13,
 				abi.Istio15,
+				abi.Istio16,
 			},
 			archiveBytes: assemblyscriptTarBytes,
 		},
@@ -166,7 +168,7 @@ If --language, --platform, or --platform-version are not provided, the CLI will 
 		fmt.Sprintf("The name of the target platform against which to build. Supported platforms are: %v", []string{"gloo", "istio"}))
 
 	cmd.PersistentFlags().StringVar(&opts.platform.Version, "platform-version", "",
-		fmt.Sprintf("The version of the target platform against which to build. Supported Istio versions are: %v. Supported Gloo versions are: %v", []string{abi.Version15x}, []string{abi.Version13x, abi.Version15x}))
+		fmt.Sprintf("The version of the target platform against which to build. Supported Istio versions are: %v. Supported Gloo versions are: %v", []string{abi.Version15x, abi.Version16x}, []string{abi.Version13x, abi.Version15x}))
 
 	cmd.PersistentFlags().BoolVar(&opts.disablePrompt, "disable-prompt", false,
 		"Disable the interactive prompt if a required parameter is not passed. If set to true and one of the required flags is not provided, wasme CLI will return an error.")

--- a/pkg/deploy/filter/envoy_filter.go
+++ b/pkg/deploy/filter/envoy_filter.go
@@ -44,19 +44,6 @@ func MakeLocalDatasource(path string) *core.AsyncDataSource {
 	}
 }
 
-// Uses the older datatypes needed by older versions of envoy-wasm, used by Istio
-func MakeLegacyLocalDatasource(path string) *core.AsyncDataSource {
-	return &core.AsyncDataSource{
-		Specifier: &core.AsyncDataSource_Local{
-			Local: &core.DataSource{
-				Specifier: &core.DataSource_Filename{
-					Filename: path,
-				},
-			},
-		},
-	}
-}
-
 func MakeWasmFilter(filter *wasmev1.FilterSpec, dataSrc *corev3.AsyncDataSource) *envoyhttp.HttpFilter {
 	filterCfg := &wasmv3.WasmService{
 		Config: &wasmv3.PluginConfig{

--- a/pkg/deploy/istio/istio_provider.go
+++ b/pkg/deploy/istio/istio_provider.go
@@ -6,22 +6,21 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
-
+	"github.com/solo-io/go-utils/protoutils"
 	"github.com/solo-io/skv2/pkg/ezkube"
 	"github.com/solo-io/wasme/pkg/abi"
+	"github.com/solo-io/wasme/pkg/cache"
+	envoyfilter "github.com/solo-io/wasme/pkg/deploy/filter"
 	v1 "github.com/solo-io/wasme/pkg/operator/api/wasme.io/v1"
+	"github.com/solo-io/wasme/pkg/pull"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/solo-io/go-utils/protoutils"
-	"github.com/solo-io/wasme/pkg/cache"
-	envoyfilter "github.com/solo-io/wasme/pkg/deploy/filter"
-	"github.com/solo-io/wasme/pkg/pull"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/pkg/deploy/istio/istio_provider.go
+++ b/pkg/deploy/istio/istio_provider.go
@@ -387,7 +387,7 @@ func (p *Provider) makeIstioEnvoyFilter(filter *v1.FilterSpec, image pull.Image,
 	)
 
 	wasmFilterConfig, err := envoyfilter.MakeIstioWasmFilter(filter,
-		envoyfilter.MakeLegacyLocalDatasource(filename),
+		envoyfilter.MakeLocalDatasource(filename),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR will allow initializing wasme filters for & deploying them to Istio 1.6.

As Istio 1.6 uses an envoy ABI which is backwards compatible with Istio 1.5, this means any wasme images targeting Istio 1.5 will work with Istio 1.6 without any changes necessary.
BOT NOTES: 
resolves https://github.com/solo-io/wasme/issues/126