### PR TITLE
Add filter load step before testing real filter + refactor release flow

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,6 +1,10 @@
 name: pull_request
 
-on: pull_request
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request: {}
 
 jobs:
   test:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,15 +1,6 @@
 name: pull_request
 
-on:
-  push:
-    branches:
-    - 'master'
-  pull_request: {}
-  release:
-    types: [published]
-
-env:
-  TAGGED_VERSION: ${{github.event.release.tag_name || '' }}
+on: pull_request
 
 jobs:
   test:
@@ -57,14 +48,6 @@ jobs:
         export FILTER_IMAGE_ISTIO_TAG=webassemblyhub.io/ilackarms/assemblyscript-test:istio-1.5
         export FILTER_BUILD_IMAGE_TAG=localhost:5000/test:v1
         make run-tests
-    - name: Release
-      if: github.event.release.tag_name
-      env:
-        KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
-        QUAY_IO_PASSWORD: ${{ secrets.QUAY_IO_PASSWORD }}
-      run: |
-        docker login quay.io --username "solo-io+solobot" --password $QUAY_IO_PASSWORD
-        make build-images operator-gen manifest-gen publish-images upload-github-release-assets publish-docs
     - name: Debug Info
       if: failure()
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,41 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+env:
+  TAGGED_VERSION: ${{github.event.release.tag_name || '' }}
+
+jobs:
+  build-and-release:
+    name: Build & Release
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14
+    - name: Install Protoc
+      uses: solo-io/setup-protoc@master
+      with:
+        version: '3.6.1'
+    - uses: azure/setup-kubectl@v1
+      id: kubectl
+      with:
+        version: 'v1.18.0'
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Release
+      if: github.event.release.tag_name
+      env:
+        KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
+        QUAY_IO_PASSWORD: ${{ secrets.QUAY_IO_PASSWORD }}
+      run: |
+        docker login quay.io --username "solo-io+solobot" --password $QUAY_IO_PASSWORD
+        make build-images operator-gen manifest-gen publish-images upload-github-release-assets publish-docs

--- a/changelog/v0.0.22/wasm-build.yaml
+++ b/changelog/v0.0.22/wasm-build.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Separate build and test CI/CD into different github workflows

--- a/test/e2e/operator/happy_path_e2e_test.go
+++ b/test/e2e/operator/happy_path_e2e_test.go
@@ -205,7 +205,7 @@ var _ = Describe("skv2Generate", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// expect header not in response
-		Eventually(testRequest, time.Minute*3).ShouldNot(ContainSubstring("hello: world"))
+		Eventually(testRequest, time.Minute*5).ShouldNot(ContainSubstring("hello: world"))
 
 	})
 })

--- a/test/e2e/operator/happy_path_e2e_test.go
+++ b/test/e2e/operator/happy_path_e2e_test.go
@@ -31,9 +31,9 @@ import (
 
 var filterDeploymentName = "myfilter"
 
-func generateCrdExample(filename, image, ns string) error {
+func generateCrdExample(filename, image, ns, headerValue string) error {
 	sv := &types.StringValue{
-		Value: "world",
+		Value: headerValue,
 	}
 	val, err := sv.Marshal()
 	if err != nil {
@@ -151,7 +151,16 @@ var _ = Describe("skv2Generate", func() {
 	It("runs the wasme operator", func() {
 		filterFile := "test/e2e/operator/test_filter.yaml"
 
-		err := generateCrdExample(filterFile, test.GetImageTagIstio(), ns)
+		err := generateCrdExample(filterFile, test.GetImageTagIstio(), ns, "init-jitter")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = test.ApplyFile(filterFile, ns)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Give Envoy a few secs to pull down the image from wasmhub
+		time.Sleep(3 * time.Second)
+
+		err = generateCrdExample(filterFile, test.GetImageTagIstio(), ns, "world")
 		Expect(err).NotTo(HaveOccurred())
 
 		err = test.ApplyFile(filterFile, ns)

--- a/test/e2e/operator/happy_path_e2e_test.go
+++ b/test/e2e/operator/happy_path_e2e_test.go
@@ -199,7 +199,7 @@ var _ = Describe("skv2Generate", func() {
 				return 0, err
 			}
 			return fd.Status.ObservedGeneration, nil
-		}).Should(Equal(int64(1)))
+		}).Should(Equal(int64(2)))
 
 		err = test.DeleteFile(filterFile, ns)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
After we write the CRD and the wasm image cache is hydrated, write it again now that the image is in the cache. Seems to help a lot with the current cache race condition.

Separately, move the Github action workflow controlling releases into its own action.