### PR TITLE
Add hugo so docs can be released as part of CI/CD

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,10 @@ jobs:
       id: kubectl
       with:
         version: 'v1.18.0'
+    - name: Setup hugo
+      uses: peaceiris/actions-hugo@v2
+      with:
+        hugo-version: "0.69.2"
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod


### PR DESCRIPTION
To fix https://github.com/solo-io/wasme/runs/981638637?check_suite_focus=true