### PR TITLE
Fix a bug in version linking

### DIFF
--- a/changelog/v0.0.26/version-fix.yaml
+++ b/changelog/v0.0.26/version-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix a bug in version linking which caused the version to be 'dev' on release.
+    issueLink: https://github.com/solo-io/wasme/issues/158

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,12 +7,10 @@
 # make serve-site -B
 
 
-
 # remove the "v" prefix
 VERSION ?= $(shell echo $(TAGGED_VERSION) | cut -c 2-)
 
-# GCLOUD_PROJECT_ID Passed by cloudbuild upload-release-assets
-GCLOUD_PROJECT_ID := $(GCLOUD_PROJECT_ID)
+GCLOUD_PROJECT_ID ?= "solo-public"
 
 GCR_REPO_PREFIX ?= gcr.io/$(GCLOUD_PROJECT_ID)
 ### REPLACE with product name

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,13 @@
 package version
 
-var DevVersion = "dev"
-
 // This will be set by the linker on release builds
-var Version = DevVersion
+var (
+	Version    string
+	DevVersion = "dev"
+)
+
+func init() {
+	if Version == "" {
+		Version = DevVersion
+	}
+}


### PR DESCRIPTION
This was causing the version to always be "dev", which caused the wrong version of Istio operator image to be deployed.
BOT NOTES: 
resolves https://github.com/solo-io/wasme/issues/158