### PR TITLE
Log into GCR before pushing docs image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,11 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Login to gcloud registry
+      id: gcloud
+      uses: elgohr/gcloud-login-action@0.2
+      with:
+        account_key: ${{ secrets.GCLOUD_KEY }}
     - name: Release
       if: github.event.release.tag_name
       env:
@@ -42,6 +47,8 @@ jobs:
         QUAY_IO_PASSWORD: ${{ secrets.QUAY_IO_PASSWORD }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAGGED_VERSION: ${{ github.event.release.tag_name }}
+        GCR_USERNAME: ${{ steps.gcloud.outputs.username }}
+        GCR_PASSWORD: ${{ steps.gcloud.outputs.password }}
       run: |
         docker login quay.io --username "solo-io+solobot" --password $QUAY_IO_PASSWORD
         make install-deps build-images operator-gen manifest-gen publish-images upload-github-release-assets publish-docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -81,6 +81,7 @@ SERVE_AS_LATEST_TAG:=$(VERSION)-latest
 ## don't bother generating manifest, just copy/modify from docs-prod repo
 # docker-push-docs: site-release manifest
 docker-push-docs: site-release
+	@echo "${GCR_PASSWORD}" | docker login -u ${GCR_USERNAME} --password-stdin gcr.io
 	docker build \
 		--build-arg VERSION=latest \
 		--build-arg PRODUCT_SCOPE=$(PRODUCT_SCOPE) \


### PR DESCRIPTION
This will require us setting `secrets.GCLOUD_KEY` to the gcloud base64 encoded service account key exported as JSON