### PR TITLE
Default GCR project at top level and docs level makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LDFLAGS := "-X github.com/solo-io/$(PROJECT)/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 
 # Passed by cloudbuild
-GCLOUD_PROJECT_ID := $(GCLOUD_PROJECT_ID)
+GCLOUD_PROJECT_ID?=solo-public
 BUILD_ID := $(BUILD_ID)
 
 #----------------------------------------------------------------------------------

--- a/changelog/v0.0.27/docs-publish.yaml
+++ b/changelog/v0.0.27/docs-publish.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: CI/CD default project ID to solo-public.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@
 # remove the "v" prefix
 VERSION ?= $(shell echo $(TAGGED_VERSION) | cut -c 2-)
 
-GCLOUD_PROJECT_ID ?= "solo-public"
+GCLOUD_PROJECT_ID ?= solo-public
 
 GCR_REPO_PREFIX ?= gcr.io/$(GCLOUD_PROJECT_ID)
 ### REPLACE with product name


### PR DESCRIPTION
For the 0.0.26 release the CI/CD process failed to automatically push the latest docs changes. `GCLOUD_PROJECT_ID` wasn't being set correctly, this should fix the CI/CD.